### PR TITLE
Update requests lib version and PySwitchLib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 netmiko==1.4.3
-git+https://github.com/StackStorm/PySwitchLib.git@v1.2.1#egg=pyswitchlib
-requests==2.18.4
+-e git+https://github.com/StackStorm/PySwitchLib.git@bb268e3c2f9b0eee690d939124b5c260993ebe57#egg=pyswitchlib
+requests>=2.22.0,<2.23.0
 six==1.11.0
 xmljson==0.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 netmiko==1.4.3
--e git+https://github.com/StackStorm/PySwitchLib.git@bb268e3c2f9b0eee690d939124b5c260993ebe57#egg=pyswitchlib
+git+https://github.com/extremenetworks/PySwitchLib.git@v1.2.2#egg=pyswitchlib
 requests>=2.22.0,<2.23.0
 six==1.11.0
 xmljson==0.1.9


### PR DESCRIPTION
This PR updates the `requests` library version to the latest version. Also, point to the new PySwitchLib commit that also updates the requests lib inside.