### PR TITLE
Upper bound on  serpent library to support python2 builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.2.4
+
+* Pin the transitive dependency `serpent` to a version that supports both python2 and python3.
+  The dependency graph is: `PySwitchLib -> Pyro4 -> serpent`.
+  
+  Contributed by Nick Maludy (@nmaludy Encore Technologies)

--- a/pack.yaml
+++ b/pack.yaml
@@ -16,6 +16,6 @@ keywords:
   - MLXe
   - MLX
   - Net Iron
-version : 1.2.3
+version : 1.2.4
 author : Extreme Networks
 email : support@extremenetworks.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 netmiko==1.4.3
 git+https://github.com/extremenetworks/PySwitchLib.git@v1.2.2#egg=pyswitchlib
 requests>=2.22.0,<2.23.0
+# transitive dependency from PySwitchLib that was not properly pinned upstream causing build errors with Python 2.7
+serpent==1.28
 six==1.11.0
 xmljson==0.1.9


### PR DESCRIPTION
This build looks like it's been failing for a while.

Digging into it looks like a transitive dependency that is pulled in doesn't have proper pinning downstream and so a version that is incompatible with Python 2.7 is being pulled in.

The offending library is `serpent`, giving us the error in CirlceCI:

```
Collecting serpent>=1.23 (from Pyro4==4.62->pyswitchlib->-r /home/circleci/repo/requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/76/9c/f25dc4e3a9d53933f0aa3fe52d606325fab226bf287af33e9bb2b8e55a17/serpent-1.30.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-rdZVFS/serpent/setup.py", line 21, in <module>
        .format(serpent_version, sys.version_info.major, sys.version_info.minor))
    RuntimeError: This version of serpent (1.30.1) doesn't support this obsolete Python version 2.7. Either upgrade to a recent Python version or downgrade serpent to a version before 1.30
```

The dependency graph is: `PySwitchLib -> Pyro4 -> serpent`

This change pins the `serpent` library to a compatible version.


Full investigative trail:
 - https://github.com/extremenetworks/PySwitchLib/blob/master/requirements.txt#L2
   - pin: `Pyro4==4.62`
 - https://github.com/irmen/Pyro4/blob/4.62/requirements.txt#L1
   - lower bound pin: `serpent>=1.23`

If `PySwitchLib` raised their requirement on Pyro4, modern versions correctly segment the requirements by Python version:
 - https://github.com/irmen/Pyro4/blob/master/requirements.txt#L1-L2